### PR TITLE
GitHub Learning Lab to GitHub Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@
 
 After you have completed this course, you are probably wondering where to go from here:
 
-- [GitHub Learning Lab](https://lab.github.com/): self-paced courses with instant bot-assisted feedback.
+- [GitHub Skills](https://skills.github.com/): self-paced courses with instant bot-assisted feedback.
 - [Microsoft Learn for GitHub](https://docs.microsoft.com/en-us/learn/github/)
 - [Join the open source community](https://github.com/open-source)


### PR DESCRIPTION
Replaced the GitHub Learning Lab link with the new GitHub Skills link.

https://skills.github.com/